### PR TITLE
Random update to fix an issue.

### DIFF
--- a/myanimelist/character.py
+++ b/myanimelist/character.py
@@ -112,7 +112,7 @@ class Character(Base):
                 anime_link = info_col.find('a')
                 link_parts = anime_link.get('href').split('/')
                 # of the form: /anime/1/Cowboy_Bebop
-                anime = self.session.anime(int(link_parts[2])).set({'title': anime_link.text})
+                anime = self.session.anime(int(link_parts[4])).set({'title': anime_link.text})
                 role = info_col.find('.//small').text
                 character_info['animeography'][anime] = role
         except:
@@ -133,7 +133,7 @@ class Character(Base):
                 manga_link = info_col.find('a')
                 link_parts = manga_link.get('href').split('/')
                 # of the form: /manga/1/Cowboy_Bebop
-                manga = self.session.manga(int(link_parts[2])).set({'title': manga_link.text})
+                manga = self.session.manga(int(link_parts[4])).set({'title': manga_link.text})
                 role = info_col.find('.//small').text
                 character_info['mangaography'][manga] = role
         except:
@@ -206,7 +206,7 @@ class Character(Base):
                         if "myanimelist.net" in voice_actor_link.get('href'):
                             person = self.session.person(int(link_parts[4])).set({'name': name})
                         else:
-                            person = self.session.person(int(link_parts[2])).set({'name': name})
+                            person = self.session.person(int(link_parts[4])).set({'name': name})
                         language = info_col.find('.//small').text
                         character_info['voice_actors'][person] = language
         except:


### PR DESCRIPTION
```
>>> s.character(290).animeography
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\Zenrac\AppData\Local\Programs\Python\Python36-32\lib\site-packages\python3_mal-0.2.10-py3.6.egg\myanimelist\base.py", line 87, in _decorator
  File "C:\Users\Zenrac\AppData\Local\Programs\Python\Python36-32\lib\site-packages\python3_mal-0.2.10-py3.6.egg\myanimelist\character.py", line 313, in load
  File "C:\Users\Zenrac\AppData\Local\Programs\Python\Python36-32\lib\site-packages\python3_mal-0.2.10-py3.6.egg\myanimelist\character.py", line 166, in parse
  File "C:\Users\Zenrac\AppData\Local\Programs\Python\Python36-32\lib\site-packages\python3_mal-0.2.10-py3.6.egg\myanimelist\character.py", line 115, in parse_sidebar
ValueError: invalid literal for int() with base 10: 'myanimelist.net'
```
I noticed that link_parts = ['https:', '', 'myanimelist.net', 'anime', '856', 'Utawarerumono']
so it cannot works with the 3th element
I made a random change that seems to work