### PR TITLE
Hotfix: Character parse in some cases fails

### DIFF
--- a/myanimelist/character.py
+++ b/myanimelist/character.py
@@ -143,8 +143,17 @@ class Character(Base):
         try:
             temp = info_panel_first.xpath("./text()")
             if len(temp) > 0:
-                num_favorites_node = temp[-1]
-                character_info['num_favorites'] = int(num_favorites_node.strip().split(': ')[1].replace(',', ''))
+                needle = None
+                for n in temp:
+                    ns = str(n)
+                    if "Favorites" in str(n):
+                        needle = ns
+                        break
+                if needle is None:
+                    character_info['num_favorites'] = 0
+                else:
+                    num_favorites_node = needle
+                    character_info['num_favorites'] = int(num_favorites_node.strip().split(': ')[1].replace(',', ''))
             else:
                 character_info['num_favorites'] = 0
         except:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ config = {
   'url': 'https://github.com/pushrbx/python3-mal',
   'download_url': 'https://github.com/pushrbx/python3-mal/archive/master.zip',
   'author_email': 'contact@pushrbx.net',
-  'version': '0.2.16',
+  'version': '0.2.17',
   'install_requires': ['urllib3>=1.21.1,<1.23', 'requests<=2.18.4', 'pytz', 'lxml', 'cssselect'],
   'tests_require': ['nose'],
   'packages': ['myanimelist']


### PR DESCRIPTION
There are cases where there are whitespace characters after the "Member Favorites" bit on the character page.
Example:
https://myanimelist.net/character/131958/Lady_Oyu