### PR TITLE
Changed behaviors: alt title parsing and user id parsing on profiles

### DIFF
--- a/myanimelist/session.py
+++ b/myanimelist/session.py
@@ -110,15 +110,14 @@ class Session(object):
         if self.session is None:
             return False
 
-        panel_url = 'https://myanimelist.net/panel.php'
+        panel_url = 'https://myanimelist.net'
         panel = self.session.get(panel_url)
         html = ht.fromstring(panel.content.decode("utf-8"))
 
         if 'Logout' in panel.content.decode("utf-8") or len(html.xpath(".//*[text()[contains(.,'Logout')]]")) > 0:
             return True
 
-        # //*[@id="header-menu"]/div[7]/div/ul/li[8]/form/a
-        if html.find("./body/div[1]/div[3]/div[1]/div/div[2]/ul/li[3]/form/a[1]") is not None:
+        if len(html.xpath("//form[@action='https://myanimelist.net/logout.php']")) > 0:
             return True
 
         return False
@@ -172,7 +171,12 @@ class Session(object):
         self.session.headers.update(mal_headers)
         if "MALHLOGSESSID" in cookies.keys():
             self.session.cookies = cookies
-        r = self.session.post('https://myanimelist.net/login.php', data=mal_payload)
+        r = self.session.post('https://myanimelist.net/login.php?from=/', data=mal_payload)
+
+        x = ht.fromstring(r.content.decode('utf-8'))
+        if len(x.xpath("//div[@class='badresult']")) > 0:
+            print('Captcha is required to login. Please login first on the website and try again.')
+
         # remove content type:
         self.session.headers.pop("Content-Type")
         return self

--- a/myanimelist/user.py
+++ b/myanimelist/user.py
@@ -202,12 +202,14 @@ class User(Base):
                 raise
 
         try:
-            # the user ID is always present in the blogfeed link.
+            # the user ID is always present in friend request link.
             user_info['id'] = -1
-            temp = info_panel_first.xpath(".//a[text()[contains(.,'Blog Feed')]]")
+            temp = info_panel_first.xpath(".//a[@id='request']")
             if len(temp) > 0:
                 all_comments_link = temp[0]
-                user_info['id'] = int(all_comments_link.get('href').split('&id=')[1])
+                all_comments_link_parts = all_comments_link.get('href').split('&id=')
+                if len(all_comments_link_parts) > 1:
+                    user_info['id'] = int(all_comments_link.get('href').split('&id=')[1])
         except:
             if not self.session.suppress_parse_exceptions:
                 raise


### PR DESCRIPTION
## Alternative titles
There are many pages where there are no alternative titles and it's a bit annoying that the logic throws an exception so I've changed  it to just produce an empty dict.

## User profiles
It looks like MAL has changed the stuff a bit. The RSS link to the blog feed doesn't contain the user id anymore. Fortunately I could find it on the friend request button.

Fixes: #34 and #35 